### PR TITLE
Refresh gremlin-server's SSL configuration on file change

### DIFF
--- a/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/SSLStoreFilesModificationWatcher.java
+++ b/gremlin-server/src/main/java/org/apache/tinkerpop/gremlin/server/util/SSLStoreFilesModificationWatcher.java
@@ -1,0 +1,107 @@
+package org.apache.tinkerpop.gremlin.server.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+/**
+ * FileWatcher monitoring changes to SSL keyStore/trustStore files.
+ * If a keyStore/trustStore file is set to null, it will be ignored.
+ * If a keyStore/trustStore file is deleted, it will be considered not modified.
+ */
+public class SSLStoreFilesModificationWatcher implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(SSLStoreFilesModificationWatcher.class);
+
+    private final Path keyStore;
+    private final Path trustStore;
+    private final Runnable onModificationRunnable;
+
+    private ZonedDateTime lastModifiedTimeKeyStore = null;
+    private ZonedDateTime lastModifiedTimeTrustStore = null;
+
+    /**
+     * Create a FileWatcher on keyStore/trustStore
+     *
+     * @param keyStore               path to the keyStore file or null to ignore
+     * @param trustStore             path to the trustStore file or null to ignore
+     * @param onModificationRunnable function to run when a modification to the keyStore or trustStore is detected
+     */
+    public SSLStoreFilesModificationWatcher(String keyStore, String trustStore, Runnable onModificationRunnable) {
+        // keyStore/trustStore can be null when not specified in gremlin-server Settings
+        this.keyStore = keyStore != null ? Paths.get(keyStore) : null;
+        this.trustStore = trustStore != null ? Paths.get(trustStore) : null;
+        this.onModificationRunnable = onModificationRunnable;
+
+        // Initialize lastModifiedTime
+        try {
+            if (this.keyStore != null) {
+                lastModifiedTimeKeyStore = getLastModifiedTime(this.keyStore);
+            }
+            if (this.trustStore != null) {
+                lastModifiedTimeTrustStore = getLastModifiedTime(this.trustStore);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        logger.info("Started listening to modifications to the KeyStore and TrustStore files");
+    }
+
+    @Override
+    public void run() {
+        try {
+            boolean keyStoreUpdated = false;
+            boolean trustStoreUpdated = false;
+            ZonedDateTime keyStoreModificationDateTime = null;
+            ZonedDateTime trustStoreModificationDateTime = null;
+
+            // Check if the keyStore file still exists and compare its last_modified_time
+            if (keyStore != null && Files.exists(keyStore)) {
+                keyStoreModificationDateTime = getLastModifiedTime(keyStore);
+                keyStoreUpdated = lastModifiedTimeKeyStore.isBefore(keyStoreModificationDateTime);
+                if (keyStoreUpdated) {
+                    logger.info("KeyStore file has been modified.");
+                }
+            }
+
+            // Check if the trustStore file still exists and compare its last_modified_time
+            if (trustStore != null && Files.exists(trustStore)) {
+                trustStoreModificationDateTime = getLastModifiedTime(trustStore);
+                trustStoreUpdated = lastModifiedTimeTrustStore.isBefore(trustStoreModificationDateTime);
+                if (trustStoreUpdated) {
+                    logger.info("TrustStore file has been modified.");
+                }
+            }
+
+            // If one of the files was updated, execute
+            if (keyStoreUpdated || trustStoreUpdated) {
+                onModificationRunnable.run();
+
+                if (keyStoreUpdated) {
+                    lastModifiedTimeKeyStore = keyStoreModificationDateTime;
+                    logger.info("Updated KeyStore configuration");
+                }
+                if (trustStoreUpdated) {
+                    lastModifiedTimeTrustStore = trustStoreModificationDateTime;
+                    logger.info("Updated TrustStore configuration");
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static ZonedDateTime getLastModifiedTime(Path filepath) throws IOException {
+        BasicFileAttributes attributes = Files.readAttributes(filepath, BasicFileAttributes.class);
+        return ZonedDateTime.ofInstant(attributes.lastModifiedTime().toInstant(), ZoneOffset.UTC);
+    }
+}

--- a/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/util/SSLStoreFilesModificationWatcherTest.java
+++ b/gremlin-server/src/test/java/org/apache/tinkerpop/gremlin/server/util/SSLStoreFilesModificationWatcherTest.java
@@ -1,0 +1,47 @@
+package org.apache.tinkerpop.gremlin.server.util;
+
+import io.cucumber.messages.internal.com.google.common.io.Files;
+import org.apache.tinkerpop.gremlin.TestHelper;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SSLStoreFilesModificationWatcherTest {
+    @Test
+    public void shouldDetectFileChange() throws IOException {
+        File keyStoreFile = TestHelper.generateTempFileFromResource(SSLStoreFilesModificationWatcherTest.class, "/server-key.jks", "");
+        File trustStoreFile = TestHelper.generateTempFileFromResource(SSLStoreFilesModificationWatcherTest.class, "/server-trust.jks", "");
+
+        AtomicBoolean modified = new AtomicBoolean(false);
+        SSLStoreFilesModificationWatcher watcher = new SSLStoreFilesModificationWatcher(keyStoreFile.getAbsolutePath(), trustStoreFile.getAbsolutePath(), () -> modified.set(true));
+
+        // No modification yet
+        watcher.run();
+        assertFalse(modified.get());
+
+        // KeyStore file modified
+        Files.touch(keyStoreFile);
+        watcher.run();
+        assertTrue(modified.get());
+        modified.set(false);
+
+        // No modification
+        watcher.run();
+        assertFalse(modified.get());
+
+        // TrustStore file modified
+        Files.touch(trustStoreFile);
+        watcher.run();
+        assertTrue(modified.get());
+        modified.set(false);
+
+        // No modification
+        watcher.run();
+        assertFalse(modified.get());
+    }
+}


### PR DESCRIPTION
When the keyStore or trustStore file changes on disk, reload them and update Netty channels to use them.

<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.7-dev -> 3.7.4 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->